### PR TITLE
update dependencies from iluminate 8 and spout 3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,15 @@
   ],
   "require": {
     "ext-json": "*",
-    "php": "^7.1",
-    "box/spout": "^2.7",
-    "illuminate/support": "^5.5|^6.0|^7.0"
+    "php": "^7.1|^8.0",
+    "box/spout": "^3",
+    "illuminate/support": "^5.5|^6.0|^7.0|^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",
-    "orchestra/testbench": "^5.0",
-    "orchestra/database": "^5.0"
+    "orchestra/testbench": "^6.0",
+    "orchestra/database": "^5.5|^6.0|^7.0|^8.0",
+    "predis/predis": "^1.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://nikazooz.github.io/laravel-simplesheet/1.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x ] Added tests to ensure against regression.

### Description of the Change


It is necessary to update the dependencies since laravel-excel has illuminate / support 8 and box / spout has been raised to 3.2. for the contribution of this library the compose.json has been modified in order to be able to use it


### Why Should This Be Added?

for the correct functioning and updating of the library. in order to be able to handle large amounts of data. something that laravel-excel is having problems

### Benefits

- memory usage reduction
- handling of large amounts of data
- avoid space overshot error

### Possible Drawbacks

- error due to some inconvenience of the spout library
- incompatibility with any version prior to laravel 8

### Verification Process


I have modified the lines locally and I have executed a compose update. I did not indicate any errors during the update


![test part 1](https://user-images.githubusercontent.com/70926103/111566975-cf0a4180-8763-11eb-9b68-4a12f2aebc10.PNG)
![test part 2](https://user-images.githubusercontent.com/70926103/111567006-dd585d80-8763-11eb-8774-a14337c430f6.JPG)


### Applicable Issues

Currently the library cannot be used because it does not have the update in the composer.json

