### PR TITLE
support for WithColumnFormatting Concern

### DIFF
--- a/src/Concerns/WithColumnFormatting.php
+++ b/src/Concerns/WithColumnFormatting.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Concerns;
+
+interface WithColumnFormatting
+{
+    /**
+     * @return array
+     */
+    public function columnFormats(): array;
+}

--- a/src/Helpers/NumberFormat.php
+++ b/src/Helpers/NumberFormat.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Helpers;
+
+class NumberFormat
+{
+    const FORMAT_GENERAL = 'General';
+
+    const FORMAT_TEXT = '@';
+
+    const FORMAT_NUMBER = '0';
+    const FORMAT_NUMBER_00 = '0.00';
+    const FORMAT_NUMBER_COMMA_SEPARATED1 = '#,##0.00';
+    const FORMAT_NUMBER_COMMA_SEPARATED2 = '#,##0.00_-';
+
+    const FORMAT_PERCENTAGE = '0%';
+    const FORMAT_PERCENTAGE_00 = '0.00%';
+
+    const FORMAT_DATE_YYYYMMDD2 = 'yyyy-mm-dd';
+    const FORMAT_DATE_YYYYMMDD = 'yyyy-mm-dd';
+    const FORMAT_DATE_DDMMYYYY = 'dd/mm/yyyy';
+    const FORMAT_DATE_DMYSLASH = 'd/m/yy';
+    const FORMAT_DATE_DMYMINUS = 'd-m-yy';
+    const FORMAT_DATE_DMMINUS = 'd-m';
+    const FORMAT_DATE_MYMINUS = 'm-yy';
+    const FORMAT_DATE_XLSX14 = 'mm-dd-yy';
+    const FORMAT_DATE_XLSX15 = 'd-mmm-yy';
+    const FORMAT_DATE_XLSX16 = 'd-mmm';
+    const FORMAT_DATE_XLSX17 = 'mmm-yy';
+    const FORMAT_DATE_XLSX22 = 'm/d/yy h:mm';
+    const FORMAT_DATE_DATETIME = 'd/m/yy h:mm';
+    const FORMAT_DATE_TIME1 = 'h:mm AM/PM';
+    const FORMAT_DATE_TIME2 = 'h:mm:ss AM/PM';
+    const FORMAT_DATE_TIME3 = 'h:mm';
+    const FORMAT_DATE_TIME4 = 'h:mm:ss';
+    const FORMAT_DATE_TIME5 = 'mm:ss';
+    const FORMAT_DATE_TIME6 = 'h:mm:ss';
+    const FORMAT_DATE_TIME7 = 'i:s.S';
+    const FORMAT_DATE_TIME8 = 'h:mm:ss;@';
+    const FORMAT_DATE_YYYYMMDDSLASH = 'yyyy/mm/dd;@';
+
+    const FORMAT_CURRENCY_USD_SIMPLE = '$#,##0.00_-';
+    const FORMAT_CURRENCY_USD = '$#,##0_-';
+    const FORMAT_CURRENCY_EUR_SIMPLE = '#,##0.00_-€';
+    const FORMAT_CURRENCY_EUR = '#,##0_-€';
+    const FORMAT_ACCOUNTING_USD = '_($* #,##0.00_);_($* \(#,##0.00\);_($* -??_);_(@_)';
+    const FORMAT_ACCOUNTING_EUR = '_(€* #,##0.00_);_(€* \(#,##0.00\);_(€* -??_);_(@_)';
+}

--- a/tests/Concerns/WithColumnFormattingTest.php
+++ b/tests/Concerns/WithColumnFormattingTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Tests\Concerns;
+
+use Box\Spout\Common\Entity\Cell;
+use Nikazooz\Simplesheet\Helpers\NumberFormat;
+use Nikazooz\Simplesheet\Tests\Data\Stubs\WithColumnFormattingExport;
+use Nikazooz\Simplesheet\Tests\TestCase;
+
+class WithColumnFormattingTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function can_export_with_column_formatting()
+    {
+        $export = new WithColumnFormattingExport();
+
+        $response = $export->store('with-column-formatting-store.xlsx');
+
+        $this->assertTrue($response);
+
+        $filePath = __DIR__.'/../Data/Disks/Local/with-column-formatting-store.xlsx';
+
+        $reader = $this->read($filePath, 'xlsx');
+
+        $sheet = $this->getSheetByIndex($reader);
+
+        foreach ($sheet->getRowIterator() as $row) {
+            /** @var Cell[] $cells */
+            $cells = $row->getCells();
+            $this->assertEquals($cells[1]->getStyle(), NumberFormat::FORMAT_NUMBER_00);
+        }
+
+        // Cleanup
+        unlink(__DIR__.'/../Data/Disks/Local/with-column-formatting-store.xlsx');
+    }
+}

--- a/tests/Data/Stubs/WithColumnFormattingExport.php
+++ b/tests/Data/Stubs/WithColumnFormattingExport.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Tests\Data\Stubs;
+
+use Nikazooz\Simplesheet\Concerns\Exportable;
+use Nikazooz\Simplesheet\Concerns\FromCollection;
+use Nikazooz\Simplesheet\Concerns\WithColumnFormatting;
+use Nikazooz\Simplesheet\Helpers\NumberFormat;
+
+class WithColumnFormattingExport implements FromCollection, WithColumnFormatting
+{
+    use Exportable;
+
+    /**
+     * @return \Illuminate\Support\Collection
+     */
+    public function collection()
+    {
+        return collect([
+            ['A1', 'B1', 'C1'],
+            ['A2', 'B2', 'C2'],
+        ]);
+    }
+
+    public function columnFormats(): array
+    {
+        return [
+            'B' => NumberFormat::FORMAT_NUMBER_00,
+        ];
+    }
+}


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://nikazooz.github.io/laravel-simplesheet/1.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [ ] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

I was migrating from Laravel/Excel to this package and I was missing the ability to format my columns.
https://docs.laravel-excel.com/3.1/exports/column-formatting.html#formatting-columns

### Why Should This Be Added?

Because you try to be a drop-in replacement for Laravel/Excel

### Benefits

The ability to format your columns

### Possible Drawbacks

Unknown 

### Verification Process

My existing exports still worked 👍 
I've also added tests, but I wasn't able to get them to run locally.

### Applicable Issues

The formatting for date format don't work yet. 
For those to work we need something like `\PhpOffice\PhpSpreadsheet\Shared\Date::dateTimeToExcel()` in the mapping to ensure correct parsing of dates.
