### PR TITLE
Add support for Custom Query Size

### DIFF
--- a/src/Concerns/WithCustomQuerySize.php
+++ b/src/Concerns/WithCustomQuerySize.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Concerns;
+
+interface WithCustomQuerySize
+{
+    /**
+     * Queued exportables are processed in chunks; each chunk being a job pushed to the queue by the QueuedWriter.
+     * In case of exportables that implement the FromQuery concern, the number of jobs is calculated by dividing the $query->count() by the chunk size.
+     * Depending on the implementation of the query() method (eg. When using a groupBy clause), this calculation might not be correct.
+     *
+     * When this is the case, you should use this method to provide a custom calculation of the query size.
+     *
+     * @return int
+     */
+    public function querySize(): int;
+}

--- a/src/Jobs/AppendDataToSheet.php
+++ b/src/Jobs/AppendDataToSheet.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Nikazooz\Simplesheet\Files\TemporaryFile;
+use Nikazooz\Simplesheet\Writer;
+
+class AppendDataToSheet implements ShouldQueue
+{
+    use Queueable, Dispatchable, ProxyFailures;
+
+    /**
+     * @var array
+     */
+    public $data = [];
+
+    /**
+     * @var string
+     */
+    public $temporaryFile;
+
+    /**
+     * @var string
+     */
+    public $writerType;
+
+    /**
+     * @var int
+     */
+    public $sheetIndex;
+
+    /**
+     * @var object
+     */
+    public $sheetExport;
+
+    /**
+     * @param object        $sheetExport
+     * @param TemporaryFile $temporaryFile
+     * @param string        $writerType
+     * @param int           $sheetIndex
+     * @param array         $data
+     */
+    public function __construct($sheetExport, TemporaryFile $temporaryFile, string $writerType, int $sheetIndex, array $data)
+    {
+        $this->sheetExport   = $sheetExport;
+        $this->data          = $data;
+        $this->temporaryFile = $temporaryFile;
+        $this->writerType    = $writerType;
+        $this->sheetIndex    = $sheetIndex;
+    }
+
+    /**
+     * Get the middleware the job should be dispatched through.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return (method_exists($this->sheetExport, 'middleware')) ? $this->sheetExport->middleware() : [];
+    }
+
+    /**
+     * @param Writer $writer
+     *
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
+     */
+    public function handle(Writer $writer)
+    {
+        $writer = $writer->reopen($this->temporaryFile, $this->writerType);
+
+        $sheet = $writer->getSheetByIndex($this->sheetIndex);
+
+        $sheet->appendRows($this->data, $this->sheetExport);
+
+        $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
+    }
+}

--- a/src/Jobs/AppendDataToSheet.php
+++ b/src/Jobs/AppendDataToSheet.php
@@ -38,19 +38,19 @@ class AppendDataToSheet implements ShouldQueue
     public $sheetExport;
 
     /**
-     * @param object        $sheetExport
-     * @param TemporaryFile $temporaryFile
-     * @param string        $writerType
-     * @param int           $sheetIndex
-     * @param array         $data
+     * @param  object  $sheetExport
+     * @param  TemporaryFile  $temporaryFile
+     * @param  string  $writerType
+     * @param  int  $sheetIndex
+     * @param  array  $data
      */
     public function __construct($sheetExport, TemporaryFile $temporaryFile, string $writerType, int $sheetIndex, array $data)
     {
-        $this->sheetExport   = $sheetExport;
-        $this->data          = $data;
+        $this->sheetExport = $sheetExport;
+        $this->data = $data;
         $this->temporaryFile = $temporaryFile;
-        $this->writerType    = $writerType;
-        $this->sheetIndex    = $sheetIndex;
+        $this->writerType = $writerType;
+        $this->sheetIndex = $sheetIndex;
     }
 
     /**
@@ -64,7 +64,7 @@ class AppendDataToSheet implements ShouldQueue
     }
 
     /**
-     * @param Writer $writer
+     * @param  Writer  $writer
      *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception

--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Nikazooz\Simplesheet\Concerns\FromQuery;
+use Nikazooz\Simplesheet\Files\TemporaryFile;
+use Nikazooz\Simplesheet\Writer;
+
+class AppendQueryToSheet implements ShouldQueue
+{
+    use Queueable, Dispatchable, ProxyFailures;
+
+    /**
+     * @var TemporaryFile
+     */
+    public $temporaryFile;
+
+    /**
+     * @var string
+     */
+    public $writerType;
+
+    /**
+     * @var int
+     */
+    public $sheetIndex;
+
+    /**
+     * @var FromQuery
+     */
+    public $sheetExport;
+
+    /**
+     * @var int
+     */
+    public $page;
+
+    /**
+     * @var int
+     */
+    public $chunkSize;
+
+    /**
+     * @param FromQuery       $sheetExport
+     * @param TemporaryFile   $temporaryFile
+     * @param string          $writerType
+     * @param int             $sheetIndex
+     * @param int             $page
+     * @param int             $chunkSize
+     */
+    public function __construct(
+        FromQuery $sheetExport,
+        TemporaryFile $temporaryFile,
+        string $writerType,
+        int $sheetIndex,
+        int $page,
+        int $chunkSize
+    ) {
+        $this->sheetExport   = $sheetExport;
+        $this->temporaryFile = $temporaryFile;
+        $this->writerType    = $writerType;
+        $this->sheetIndex    = $sheetIndex;
+        $this->page          = $page;
+        $this->chunkSize     = $chunkSize;
+    }
+
+    /**
+     * Get the middleware the job should be dispatched through.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return (method_exists($this->sheetExport, 'middleware')) ? $this->sheetExport->middleware() : [];
+    }
+
+    /**
+     * @param Writer $writer
+     *
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
+     */
+    public function handle(Writer $writer)
+    {
+        $writer = $writer->reopen($this->temporaryFile, $this->writerType);
+
+        $sheet = $writer->getSheetByIndex($this->sheetIndex);
+
+        $query = $this->sheetExport->query()->forPage($this->page, $this->chunkSize);
+
+        $sheet->appendRows($query->get(), $this->sheetExport);
+
+        $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
+    }
+}

--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -44,12 +44,12 @@ class AppendQueryToSheet implements ShouldQueue
     public $chunkSize;
 
     /**
-     * @param FromQuery       $sheetExport
-     * @param TemporaryFile   $temporaryFile
-     * @param string          $writerType
-     * @param int             $sheetIndex
-     * @param int             $page
-     * @param int             $chunkSize
+     * @param  FromQuery  $sheetExport
+     * @param  TemporaryFile  $temporaryFile
+     * @param  string  $writerType
+     * @param  int  $sheetIndex
+     * @param  int  $page
+     * @param  int  $chunkSize
      */
     public function __construct(
         FromQuery $sheetExport,
@@ -59,12 +59,12 @@ class AppendQueryToSheet implements ShouldQueue
         int $page,
         int $chunkSize
     ) {
-        $this->sheetExport   = $sheetExport;
+        $this->sheetExport = $sheetExport;
         $this->temporaryFile = $temporaryFile;
-        $this->writerType    = $writerType;
-        $this->sheetIndex    = $sheetIndex;
-        $this->page          = $page;
-        $this->chunkSize     = $chunkSize;
+        $this->writerType = $writerType;
+        $this->sheetIndex = $sheetIndex;
+        $this->page = $page;
+        $this->chunkSize = $chunkSize;
     }
 
     /**
@@ -78,7 +78,7 @@ class AppendQueryToSheet implements ShouldQueue
     }
 
     /**
-     * @param Writer $writer
+     * @param  Writer  $writer
      *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception

--- a/src/Jobs/CloseSheet.php
+++ b/src/Jobs/CloseSheet.php
@@ -33,21 +33,21 @@ class CloseSheet implements ShouldQueue
     private $sheetIndex;
 
     /**
-     * @param object        $sheetExport
-     * @param TemporaryFile $temporaryFile
-     * @param string        $writerType
-     * @param int           $sheetIndex
+     * @param  object  $sheetExport
+     * @param  TemporaryFile  $temporaryFile
+     * @param  string  $writerType
+     * @param  int  $sheetIndex
      */
     public function __construct($sheetExport, TemporaryFile $temporaryFile, string $writerType, int $sheetIndex)
     {
-        $this->sheetExport   = $sheetExport;
+        $this->sheetExport = $sheetExport;
         $this->temporaryFile = $temporaryFile;
-        $this->writerType    = $writerType;
-        $this->sheetIndex    = $sheetIndex;
+        $this->writerType = $writerType;
+        $this->sheetIndex = $sheetIndex;
     }
 
     /**
-     * @param Writer $writer
+     * @param  Writer  $writer
      *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception

--- a/src/Jobs/CloseSheet.php
+++ b/src/Jobs/CloseSheet.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Nikazooz\Simplesheet\Concerns\WithEvents;
+use Nikazooz\Simplesheet\Files\TemporaryFile;
+use Nikazooz\Simplesheet\Writer;
+
+class CloseSheet implements ShouldQueue
+{
+    use Queueable, ProxyFailures;
+
+    /**
+     * @var object
+     */
+    private $sheetExport;
+
+    /**
+     * @var string
+     */
+    private $temporaryFile;
+
+    /**
+     * @var string
+     */
+    private $writerType;
+
+    /**
+     * @var int
+     */
+    private $sheetIndex;
+
+    /**
+     * @param object        $sheetExport
+     * @param TemporaryFile $temporaryFile
+     * @param string        $writerType
+     * @param int           $sheetIndex
+     */
+    public function __construct($sheetExport, TemporaryFile $temporaryFile, string $writerType, int $sheetIndex)
+    {
+        $this->sheetExport   = $sheetExport;
+        $this->temporaryFile = $temporaryFile;
+        $this->writerType    = $writerType;
+        $this->sheetIndex    = $sheetIndex;
+    }
+
+    /**
+     * @param Writer $writer
+     *
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
+     */
+    public function handle(Writer $writer)
+    {
+        $writer = $writer->reopen(
+            $this->temporaryFile,
+            $this->writerType
+        );
+
+        $sheet = $writer->getSheetByIndex($this->sheetIndex);
+
+        if ($this->sheetExport instanceof WithEvents) {
+            $sheet->registerListeners($this->sheetExport->registerEvents());
+        }
+
+        $sheet->close($this->sheetExport);
+
+        $writer->write(
+            $this->sheetExport,
+            $this->temporaryFile,
+            $this->writerType
+        );
+    }
+}

--- a/src/Jobs/ProxyFailures.php
+++ b/src/Jobs/ProxyFailures.php
@@ -7,7 +7,7 @@ use Throwable;
 trait ProxyFailures
 {
     /**
-     * @param Throwable $e
+     * @param  Throwable  $e
      */
     public function failed(Throwable $e)
     {

--- a/src/Jobs/ProxyFailures.php
+++ b/src/Jobs/ProxyFailures.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Jobs;
+
+use Throwable;
+
+trait ProxyFailures
+{
+    /**
+     * @param Throwable $e
+     */
+    public function failed(Throwable $e)
+    {
+        if (method_exists($this->sheetExport, 'failed')) {
+            $this->sheetExport->failed($e);
+        }
+    }
+}

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -2,13 +2,29 @@
 
 namespace Nikazooz\Simplesheet;
 
+use Illuminate\Support\Collection;
+use Nikazooz\Simplesheet\Jobs\CloseSheet;
+use Nikazooz\Simplesheet\Concerns\FromQuery;
+use Nikazooz\Simplesheet\Files\TemporaryFile;
 use Illuminate\Foundation\Bus\PendingDispatch;
+use Nikazooz\Simplesheet\Jobs\AppendDataToSheet;
+use Nikazooz\Simplesheet\Concerns\FromCollection;
+use Nikazooz\Simplesheet\Jobs\AppendQueryToSheet;
 use Nikazooz\Simplesheet\Files\TemporaryFileFactory;
 use Nikazooz\Simplesheet\Jobs\QueueExport;
 use Nikazooz\Simplesheet\Jobs\StoreQueuedExport;
+use Nikazooz\Simplesheet\Concerns\WithMultipleSheets;
+use Nikazooz\Simplesheet\Concerns\WithCustomChunkSize;
+use Traversable;
+use Nikazooz\Simplesheet\Concerns\WithCustomQuerySize;
 
 class QueuedWriter
 {
+    /**
+     * @var int
+     */
+    protected $chunkSize;
+
     /**
      * @var \Nikazooz\Simplesheet\Files\TemporaryFileFactory
      */
@@ -20,6 +36,7 @@ class QueuedWriter
      */
     public function __construct(TemporaryFileFactory $temporaryFileFactory)
     {
+        $this->chunkSize            = config('excel.exports.chunk_size', 1000);
         $this->temporaryFileFactory = $temporaryFileFactory;
     }
 
@@ -36,10 +53,126 @@ class QueuedWriter
         $extension = pathinfo($filePath, PATHINFO_EXTENSION);
         $temporaryFile = $this->temporaryFileFactory->make($extension);
 
+        $jobs = $this->buildExportJobs($export, $temporaryFile, $writerType);
+
+        $jobs->push(new StoreQueuedExport(
+            $temporaryFile,
+            $filePath,
+            $disk,
+            $diskOptions
+        ));
+
         return new PendingDispatch(
-            (new QueueExport($export, $temporaryFile, $writerType))->chain([
-                new StoreQueuedExport($temporaryFile, $filePath, $disk, $diskOptions),
-            ])
+            (new QueueExport($export, $temporaryFile, $writerType))->chain($jobs->toArray())
         );
+    }
+
+    /**
+     * @param object        $export
+     * @param TemporaryFile $temporaryFile
+     * @param string        $writerType
+     *
+     * @return Collection
+     */
+    private function buildExportJobs($export, TemporaryFile $temporaryFile, string $writerType): Collection
+    {
+        $sheetExports = [$export];
+        if ($export instanceof WithMultipleSheets) {
+            $sheetExports = $export->sheets();
+        }
+
+        $jobs = new Collection;
+        foreach ($sheetExports as $sheetIndex => $sheetExport) {
+            if ($sheetExport instanceof FromCollection) {
+                $jobs = $jobs->merge($this->exportCollection($sheetExport, $temporaryFile, $writerType, $sheetIndex));
+            } elseif ($sheetExport instanceof FromQuery) {
+                $jobs = $jobs->merge($this->exportQuery($sheetExport, $temporaryFile, $writerType, $sheetIndex));
+            }
+
+            $jobs->push(new CloseSheet($sheetExport, $temporaryFile, $writerType, $sheetIndex));
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * @param FromCollection $export
+     * @param TemporaryFile  $temporaryFile
+     * @param string         $writerType
+     * @param int            $sheetIndex
+     *
+     * @return Collection
+     */
+    private function exportCollection(
+        FromCollection $export,
+        TemporaryFile $temporaryFile,
+        string $writerType,
+        int $sheetIndex
+    ): Collection {
+        return $export
+            ->collection()
+            ->chunk($this->getChunkSize($export))
+            ->map(function ($rows) use ($writerType, $temporaryFile, $sheetIndex, $export) {
+                if ($rows instanceof Traversable) {
+                    $rows = iterator_to_array($rows);
+                }
+
+                return new AppendDataToSheet(
+                    $export,
+                    $temporaryFile,
+                    $writerType,
+                    $sheetIndex,
+                    $rows
+                );
+            });
+    }
+
+    /**
+     * @param FromQuery     $export
+     * @param TemporaryFile $temporaryFile
+     * @param string        $writerType
+     * @param int           $sheetIndex
+     *
+     * @return Collection
+     */
+    private function exportQuery(
+        FromQuery $export,
+        TemporaryFile $temporaryFile,
+        string $writerType,
+        int $sheetIndex
+    ): Collection {
+        $query = $export->query();
+
+        $count = $export instanceof WithCustomQuerySize ? $export->querySize() : $query->count();
+        $spins = ceil($count / $this->getChunkSize($export));
+
+        $jobs = new Collection();
+
+        for ($page = 1; $page <= $spins; $page++) {
+            $jobs->push(new AppendQueryToSheet(
+                $export,
+                $temporaryFile,
+                $writerType,
+                $sheetIndex,
+                $page,
+                $this->getChunkSize($export)
+            ));
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * @param object|WithCustomChunkSize $export
+     *
+     * @return int
+     */
+    private function getChunkSize($export): int
+    {
+        if ($export instanceof WithCustomChunkSize) {
+            return $export->chunkSize();
+        }
+
+        return $this->chunkSize;
     }
 }

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -68,10 +68,9 @@ class QueuedWriter
     }
 
     /**
-     * @param object        $export
-     * @param TemporaryFile $temporaryFile
-     * @param string        $writerType
-     *
+     * @param  object  $export
+     * @param  TemporaryFile  $temporaryFile
+     * @param  string  $writerType
      * @return Collection
      */
     private function buildExportJobs($export, TemporaryFile $temporaryFile, string $writerType): Collection
@@ -100,7 +99,6 @@ class QueuedWriter
      * @param  TemporaryFile  $temporaryFile
      * @param  string  $writerType
      * @param  int  $sheetIndex
-     *
      * @return Collection
      */
     private function exportCollection(
@@ -132,7 +130,6 @@ class QueuedWriter
      * @param  TemporaryFile  $temporaryFile
      * @param  string  $writerType
      * @param  int  $sheetIndex
-     *
      * @return Collection
      */
     private function exportQuery(
@@ -164,7 +161,6 @@ class QueuedWriter
 
     /**
      * @param  object|WithCustomChunkSize  $export
-     *
      * @return int
      */
     private function getChunkSize($export): int

--- a/src/QueuedWriter.php
+++ b/src/QueuedWriter.php
@@ -2,21 +2,21 @@
 
 namespace Nikazooz\Simplesheet;
 
-use Illuminate\Support\Collection;
-use Nikazooz\Simplesheet\Jobs\CloseSheet;
-use Nikazooz\Simplesheet\Concerns\FromQuery;
-use Nikazooz\Simplesheet\Files\TemporaryFile;
 use Illuminate\Foundation\Bus\PendingDispatch;
-use Nikazooz\Simplesheet\Jobs\AppendDataToSheet;
+use Illuminate\Support\Collection;
 use Nikazooz\Simplesheet\Concerns\FromCollection;
-use Nikazooz\Simplesheet\Jobs\AppendQueryToSheet;
+use Nikazooz\Simplesheet\Concerns\FromQuery;
+use Nikazooz\Simplesheet\Concerns\WithCustomChunkSize;
+use Nikazooz\Simplesheet\Concerns\WithCustomQuerySize;
+use Nikazooz\Simplesheet\Concerns\WithMultipleSheets;
+use Nikazooz\Simplesheet\Files\TemporaryFile;
 use Nikazooz\Simplesheet\Files\TemporaryFileFactory;
+use Nikazooz\Simplesheet\Jobs\AppendDataToSheet;
+use Nikazooz\Simplesheet\Jobs\AppendQueryToSheet;
+use Nikazooz\Simplesheet\Jobs\CloseSheet;
 use Nikazooz\Simplesheet\Jobs\QueueExport;
 use Nikazooz\Simplesheet\Jobs\StoreQueuedExport;
-use Nikazooz\Simplesheet\Concerns\WithMultipleSheets;
-use Nikazooz\Simplesheet\Concerns\WithCustomChunkSize;
 use Traversable;
-use Nikazooz\Simplesheet\Concerns\WithCustomQuerySize;
 
 class QueuedWriter
 {
@@ -36,7 +36,7 @@ class QueuedWriter
      */
     public function __construct(TemporaryFileFactory $temporaryFileFactory)
     {
-        $this->chunkSize            = config('excel.exports.chunk_size', 1000);
+        $this->chunkSize = config('excel.exports.chunk_size', 1000);
         $this->temporaryFileFactory = $temporaryFileFactory;
     }
 
@@ -96,10 +96,10 @@ class QueuedWriter
     }
 
     /**
-     * @param FromCollection $export
-     * @param TemporaryFile  $temporaryFile
-     * @param string         $writerType
-     * @param int            $sheetIndex
+     * @param  FromCollection  $export
+     * @param  TemporaryFile  $temporaryFile
+     * @param  string  $writerType
+     * @param  int  $sheetIndex
      *
      * @return Collection
      */
@@ -128,10 +128,10 @@ class QueuedWriter
     }
 
     /**
-     * @param FromQuery     $export
-     * @param TemporaryFile $temporaryFile
-     * @param string        $writerType
-     * @param int           $sheetIndex
+     * @param  FromQuery  $export
+     * @param  TemporaryFile  $temporaryFile
+     * @param  string  $writerType
+     * @param  int  $sheetIndex
      *
      * @return Collection
      */
@@ -163,7 +163,7 @@ class QueuedWriter
     }
 
     /**
-     * @param object|WithCustomChunkSize $export
+     * @param  object|WithCustomChunkSize  $export
      *
      * @return int
      */

--- a/tests/Data/Stubs/FromUsersQueryExportWithMappingAndCustomQuerySize.php
+++ b/tests/Data/Stubs/FromUsersQueryExportWithMappingAndCustomQuerySize.php
@@ -4,10 +4,10 @@ namespace Nikazooz\Simplesheet\Tests\Data\Stubs;
 
 use Nikazooz\Simplesheet\Concerns\Exportable;
 use Nikazooz\Simplesheet\Concerns\FromQuery;
+use Nikazooz\Simplesheet\Concerns\WithCustomQuerySize;
 use Nikazooz\Simplesheet\Concerns\WithEvents;
 use Nikazooz\Simplesheet\Concerns\WithMapping;
 use Nikazooz\Simplesheet\Events\BeforeSheet;
-use Nikazooz\Simplesheet\Concerns\WithCustomQuerySize;
 use Nikazooz\Simplesheet\Tests\Data\Stubs\Database\User;
 
 class FromUsersQueryExportWithMappingAndCustomQuerySize implements FromQuery, WithMapping, WithEvents, WithCustomQuerySize

--- a/tests/Data/Stubs/FromUsersQueryExportWithMappingAndCustomQuerySize.php
+++ b/tests/Data/Stubs/FromUsersQueryExportWithMappingAndCustomQuerySize.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Tests\Data\Stubs;
+
+use Nikazooz\Simplesheet\Concerns\Exportable;
+use Nikazooz\Simplesheet\Concerns\FromQuery;
+use Nikazooz\Simplesheet\Concerns\WithEvents;
+use Nikazooz\Simplesheet\Concerns\WithMapping;
+use Nikazooz\Simplesheet\Events\BeforeSheet;
+use Nikazooz\Simplesheet\Concerns\WithCustomQuerySize;
+use Nikazooz\Simplesheet\Tests\Data\Stubs\Database\User;
+
+class FromUsersQueryExportWithMappingAndCustomQuerySize implements FromQuery, WithMapping, WithEvents, WithCustomQuerySize
+{
+    use Exportable;
+
+    /**
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function query()
+    {
+        return User::query();
+    }
+
+    /**
+     * @return array
+     */
+    public function registerEvents(): array
+    {
+        return [
+            BeforeSheet::class => function (BeforeSheet $event) {
+                $event->sheet->chunkSize(10);
+            },
+        ];
+    }
+
+    /**
+     * @param  \Nikazooz\Simplesheet\Tests\Data\Stubs\Database\User  $row
+     * @return array
+     */
+    public function map($row): array
+    {
+        return [
+            'name' => $row->name,
+        ];
+    }
+
+    public function querySize(): int
+    {
+        return $this->query()->count();
+    }
+}

--- a/tests/Data/Stubs/FromUsersQueryWithCustomQuerySizeExport.php
+++ b/tests/Data/Stubs/FromUsersQueryWithCustomQuerySizeExport.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Tests\Data\Stubs;
+
+use Illuminate\Database\Query\Builder;
+use Nikazooz\Simplesheet\Concerns\Exportable;
+use Nikazooz\Simplesheet\Concerns\FromQuery;
+use Nikazooz\Simplesheet\Concerns\WithCustomChunkSize;
+use Nikazooz\Simplesheet\Concerns\WithCustomQuerySize;
+use Nikazooz\Simplesheet\Tests\Data\Stubs\Database\User;
+
+class FromUsersQueryWithCustomQuerySizeExport implements FromQuery, WithCustomChunkSize, WithCustomQuerySize
+{
+    use Exportable;
+
+    /**
+     * @return Builder
+     */
+    public function query()
+    {
+        return User::query();
+    }
+
+    /**
+     * @return int
+     */
+    public function chunkSize(): int
+    {
+        return 10;
+    }
+
+    public function querySize(): int
+    {
+        return $this->query()->count();
+    }
+}

--- a/tests/QueuedQueryExportWithCustomQuerySizeTest.php
+++ b/tests/QueuedQueryExportWithCustomQuerySizeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Nikazooz\Simplesheet\Tests;
+
+use Nikazooz\Simplesheet\Tests\Data\Stubs\AfterQueueExportJob;
+use Nikazooz\Simplesheet\Tests\Data\Stubs\Database\User;
+use Nikazooz\Simplesheet\Tests\Data\Stubs\FromUsersQueryWithCustomQuerySizeExport;
+use Nikazooz\Simplesheet\Tests\Data\Stubs\FromUsersQueryExportWithMappingAndCustomQuerySize;
+
+class QueuedQueryExportWithCustomQuerySizeTest extends TestCase
+{
+    /**
+     * Setup the test environment.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadLaravelMigrations(['--database' => 'testing']);
+        $this->withFactories(__DIR__.'/Data/Stubs/Database/Factories');
+
+        factory(User::class)->times(100)->create([]);
+    }
+
+    /**
+     * @test
+     */
+    public function can_queue_an_export_with_custom_query_size()
+    {
+        $export = new FromUsersQueryWithCustomQuerySizeExport();
+
+        $export->queue('queued-query-export-with-custom-query-size.xlsx')->chain([
+            new AfterQueueExportJob(__DIR__.'/Data/Disks/Local/queued-query-export-with-custom-query-size.xlsx'),
+        ]);
+
+        $actual = $this->readAsArray(__DIR__.'/Data/Disks/Local/queued-query-export-with-custom-query-size.xlsx', 'xlsx');
+
+        $this->assertCount(100, $actual);
+
+        // 6 of the 7 columns in export, excluding the "hidden" password column.
+        $this->assertCount(6, $actual[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function can_queue_an_export_with_mapping_and_custom_query_size()
+    {
+        $export = new FromUsersQueryExportWithMappingAndCustomQuerySize();
+
+        $export->queue('queued-query-export-with-mapping-and-custom-query-size.xlsx')->chain([
+            new AfterQueueExportJob(__DIR__.'/Data/Disks/Local/queued-query-export-with-mapping-and-custom-query-size.xlsx'),
+        ]);
+
+        $actual = $this->readAsArray(__DIR__.'/Data/Disks/Local/queued-query-export-with-mapping-and-custom-query-size.xlsx', 'xlsx');
+
+        $this->assertCount(100, $actual);
+
+        // Only 1 column when using map()
+        $this->assertCount(1, $actual[0]);
+        $this->assertEquals(User::value('name'), $actual[0][0]);
+    }
+}

--- a/tests/QueuedQueryExportWithCustomQuerySizeTest.php
+++ b/tests/QueuedQueryExportWithCustomQuerySizeTest.php
@@ -4,8 +4,8 @@ namespace Nikazooz\Simplesheet\Tests;
 
 use Nikazooz\Simplesheet\Tests\Data\Stubs\AfterQueueExportJob;
 use Nikazooz\Simplesheet\Tests\Data\Stubs\Database\User;
-use Nikazooz\Simplesheet\Tests\Data\Stubs\FromUsersQueryWithCustomQuerySizeExport;
 use Nikazooz\Simplesheet\Tests\Data\Stubs\FromUsersQueryExportWithMappingAndCustomQuerySize;
+use Nikazooz\Simplesheet\Tests\Data\Stubs\FromUsersQueryWithCustomQuerySizeExport;
 
 class QueuedQueryExportWithCustomQuerySizeTest extends TestCase
 {


### PR DESCRIPTION
### Requirements

Please take note of our contributing guidelines: https://nikazooz.github.io/laravel-simplesheet/1.0/getting-started/contributing
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

Mark the following tasks as done:

* [x] Checked the codebase to ensure that your feature doesn't already exist.
* [x] Checked the pull requests to ensure that another person hasn't already submitted the feature or fix.
* [x] Adjusted the Documentation.
* [x] Added tests to ensure against regression.

### Description of the Change

Add the [CustomQuerySize](https://docs.laravel-excel.com/3.1/exports/queued.html#custom-query-size) support

### Why Should This Be Added?

Because you try to be a drop-in replacement for Laravel/Excel

### Benefits

As in [Laravel Excel](https://docs.laravel-excel.com/3.1/exports/queued.html#custom-query-size), Custom Query Size could be usefull in certain cases (for fromQuery exports).

### Possible Drawbacks

no breaking changes

### Verification Process

My existing exports still worked and add some test

### Applicable Issues


